### PR TITLE
Lockdown when env var set

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ Use Outside-In Test-Driven Development to implement a new screen:
 
 `thor export:children FILE`
 : Export children (by default, only completely submitted children) to FILE (by default `tmp/all.csv`). Run `thor help export:children` for more options
+
+### Predeployment/Staging Lockdown
+
+If `AUTH_USERNAME` environment variable is set, the application will use `AUTH_USERNAME` and `AUTH_PASSWORD` via http authentication for each request.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include AuthenticationConcern
   before_action :set_sentry_context
   before_action :check_locale
   around_action :switch_locale

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -1,0 +1,13 @@
+module AuthenticationConcern
+  extend ActiveSupport::Concern
+  included do
+    before_action :http_authenticate
+  end
+  def http_authenticate
+    return if ENV['AUTH_USERNAME'].blank?
+
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['AUTH_USERNAME'] && password == ENV['AUTH_PASSWORD']
+    end
+  end
+end

--- a/spec/features/lockdown_spec.rb
+++ b/spec/features/lockdown_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Lockdown', type: :feature do
+  before do
+    stub_const 'ENV', ENV.to_h.merge('AUTH_PASSWORD' => 'i_like_turtles', 'AUTH_USERNAME' => 'cris_p_bacon')
+    @credentials = ActionController::HttpAuthentication::Basic.encode_credentials 'cris_p_bacon', 'i_like_turtles'
+  end
+
+  it 'requires authentication when set' do
+    visit '/'
+    expect(page).to have_http_status(:unauthorized)
+  end
+
+  it 'works when authorized' do
+    page.driver.browser.authorize('cris_p_bacon', 'i_like_turtles')
+    visit '/'
+    expect(page).to have_text 'Get help buying food while schools are closed'
+  end
+end


### PR DESCRIPTION
Whenever the `AUTH_USERNAME` env variable is set (probably this should happen in staging server), turn on HTTP AUTH, using `AUTH_USERNAME` and `AUTH_PASSWORD`, set in env. 