### PR TITLE
Modifies child model to use includes rather than joins

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -7,8 +7,6 @@ class ChildrenController < FormsController
 
   def index
     @children = Child.submitted
-
-    @children = Child.submitted
     @children = @children.submitted_after(DateTime.parse(params['after'])) if params['after'].present?
     @children = @children.submitted_before(DateTime.parse(params['before'])) if params['before'].present?
     @children = @children.by_household(params['hhid']) if params['hhid'].present?

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -6,13 +6,13 @@ class Child < ApplicationRecord
     private_school: 1
   }
 
-  scope :submitted, -> { joins(:household).where.not(households: { submitted_at: nil }) }
-  scope :unsubmitted, -> { joins(:household).where(households: { submitted_at: nil }) }
+  scope :submitted, -> { includes(:household).where.not(households: { submitted_at: nil }) }
+  scope :unsubmitted, -> { includes(:household).where(households: { submitted_at: nil }) }
 
   scope :submitted_after, ->(submitted_after_time) { submitted.where('households.submitted_at >= ?', submitted_after_time) }
   scope :submitted_before, ->(submitted_before_time) { submitted.where('households.submitted_at < ?', submitted_before_time) }
 
-  scope :by_household, ->(hhid) { joins(:household).where(households: { id: hhid }) }
+  scope :by_household, ->(hhid) { includes(:household).where(households: { id: hhid }) }
 
   def full_name
     "#{first_name} #{last_name}"


### PR DESCRIPTION
This is the same code change for MN to modify the child scopes to use `includes` rather than `joins` so that `household` is preloaded when working with exports