### PR TITLE
Updates the signature page to handle null bytes being sent

### DIFF
--- a/app/forms/signature_form.rb
+++ b/app/forms/signature_form.rb
@@ -1,8 +1,13 @@
 class SignatureForm < Form
+  NULL_BYTE = "\u0000".freeze
   set_attributes_for :household, :signature
   validates_presence_of :signature, message: proc { I18n.t('validations.signature') }
 
   def save
-    household.update(attributes_for(:household).merge({ submitted_at: Time.zone.now }))
+    form_attributes = attributes_for(:household)
+    attributes = {
+      signature: form_attributes[:signature].gsub(NULL_BYTE, ' ').strip
+    }
+    household.update(attributes.merge({ submitted_at: Time.zone.now }))
   end
 end

--- a/spec/forms/signature_form_spec.rb
+++ b/spec/forms/signature_form_spec.rb
@@ -13,5 +13,17 @@ describe SignatureForm do
       expect(household.signature).to eq('John Hancock')
       expect(household.submitted_at).not_to be_nil
     end
+
+    it 'handles null bytes by stripping them out' do
+      household = Household.create(is_eligible: :yes)
+      form = described_class.new(household, { signature: "John\u0000Hancock\u0000" })
+      form.valid?
+      form.save
+
+      household.reload
+
+      expect(household.signature).to eq('John Hancock')
+      expect(household.submitted_at).not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
We saw several instances in Sentry where people on the signature page were getting errors when submitting due to "null bytes". Based on https://stackoverflow.com/questions/29320369/coping-with-string-contains-null-byte-sent-from-users this strips them out by replacing them with empty strings, and then `strip`ping the resulting string